### PR TITLE
Disallow more than two levels of depth to compound namespaces

### DIFF
--- a/proposed/extended-coding-style-guide.md
+++ b/proposed/extended-coding-style-guide.md
@@ -163,7 +163,8 @@ class FooBar
 
 ```
 
-Compound namespaces with a depth of two or more MUST not be used.
+Compound namespaces with a depth of two or more MUST not be used. Therefore the
+following is the maximum compounding depth allowed:
 ```php
 <?php
 

--- a/proposed/extended-coding-style-guide.md
+++ b/proposed/extended-coding-style-guide.md
@@ -163,8 +163,7 @@ class FooBar
 
 ```
 
-Compound namespaces with a depth of two or more MUST not be used. Therefore the
-following is the maximum compounding depth allowed:
+Compound namespaces with a depth of two or more MUST not be used.
 ```php
 <?php
 

--- a/proposed/extended-coding-style-guide.md
+++ b/proposed/extended-coding-style-guide.md
@@ -163,6 +163,19 @@ class FooBar
 
 ```
 
+Compound namespaces with a depth of two or more MUST not be used. Therefore the
+following is the maximum compounding depth allowed:
+```php
+<?php
+
+use Vendor\Package\Namespace\{
+    SubnamespaceOne\ClassA,
+    SubnamespaceOne\ClassB,
+    SubnamespaceTwo\ClassY,
+    ClassZ,
+};
+```
+
 All files MUST declare strict types.
 
 Files containing only PHP MUST contain the strict type declarations on the


### PR DESCRIPTION
- [x] Disallow more than two levels of depth to compound namespaces

Closes #15 

Rationale: Any further depth and it is becoming ugly, probably unnecessary and hard to read whereas this level of depth may be useful. Also see https://github.com/cs-extended/fig-standards/pull/2#discussion_r41806158
